### PR TITLE
chore: bump version to 8.16.3-SNAPSHOT

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Transport = "8.16.2-SNAPSHOT"
+const Transport = "8.16.3-SNAPSHOT"


### PR DESCRIPTION
Bumps version to 8.16.3-SNAPSHOT after release.

Auto-generated by GitHub Actions.